### PR TITLE
Fix unique exits for power distribution room

### DIFF
--- a/alien_starship_adventure.py
+++ b/alien_starship_adventure.py
@@ -183,7 +183,7 @@ class AlienStarshipGame:
             ("water_recycling", {"west": "waste_processing", "south": "engine_room_lower"}),
             ("emergency_stairwell_1", {"down": "docking_bay", "up": "emergency_stairwell_2"}),
             ("airlock_1", {"north": "power_distribution_1"}),
-            ("power_distribution_1", {"south": "airlock_1", "south": "maintenance_shaft_1"}),
+            ("power_distribution_1", {"south": "airlock_1", "west": "maintenance_shaft_1"}),
             
             # Level 2 connections
             ("emergency_stairwell_2", {"down": "emergency_stairwell_1", "up": "emergency_stairwell_3", "north": "corridor_2a"}),


### PR DESCRIPTION
## Summary
- ensure `power_distribution_1` exit keys are unique

## Testing
- `python3 -m py_compile alien_starship_adventure.py`
- `python3 alien_starship_adventure.py <<'EOF'
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685ef25075408325aca3a52b52206a19