### PR TITLE
Add revisit message for rooms

### DIFF
--- a/alien_starship_adventure.py
+++ b/alien_starship_adventure.py
@@ -280,12 +280,18 @@ class AlienStarshipGame:
                 self.rooms[room_name].lock_description = lock_desc
 
     def display_room(self):
-        """Display current room information"""
+        """Display current room information
+
+        Prints a full description the first time a room is visited and a
+        shorter reminder on subsequent visits.
+        """
         room = self.player.current_room
         print(f"\n=== {room.name.replace('_', ' ').title()} (Level {room.level}) ===")
-        print(room.description)
-        
-        if not room.visited:
+
+        if room.visited:
+            print(f"You are back in the {room.name.replace('_', ' ')}.")
+        else:
+            print(room.description)
             room.visited = True
         
         if room.items:


### PR DESCRIPTION
## Summary
- update `display_room` to show a shorter message when revisiting rooms

## Testing
- `python3 -m py_compile alien_starship_adventure.py`


------
https://chatgpt.com/codex/tasks/task_e_685ef268d94c8325bbbad96e86166a3f