### PR TITLE
Fix missing random import

### DIFF
--- a/alien_starship_adventure.py
+++ b/alien_starship_adventure.py
@@ -6,6 +6,7 @@ Objective: Find escape pods to get off the ship by collecting items and solving 
 """
 
 from typing import Optional
+import random
 
 class Item:
     def __init__(self, name: str, description: str, usable: bool = False):


### PR DESCRIPTION
## Summary
- import the `random` module in the adventure game to avoid NameError

## Testing
- `python3 -m py_compile alien_starship_adventure.py`
- `echo 'quit' | python3 alien_starship_adventure.py`

------
https://chatgpt.com/codex/tasks/task_e_685efc1591988325a8fde150f7a910b4